### PR TITLE
Workaround author ordering issue

### DIFF
--- a/elements_xwalks/maps/hyrax-XwalkIn-map.xml
+++ b/elements_xwalks/maps/hyrax-XwalkIn-map.xml
@@ -385,6 +385,10 @@ ISSUES:
         <xwalk:field-source from="/mods:mods/mods:name[@type = 'personal' and mods:role/mods:roleTerm/text() = 'Author']" select-using="xpath">
           <xwalk:field-source data-part="person:firstnames" from="/*/mods:namePart[@type = 'given']" select-using="xpath"/>
           <xwalk:field-source data-part="person:lastname" from="/*/mods:namePart[@type = 'family']" select-using="xpath"/>
+          <!-- Workaround author ordering issue - GitHub issue 181 (https://github.com/tomwrobel/ora_data_model/issues/181), support ticket https://support.symplectic.co.uk/a/tickets/260733. -->
+          <!-- Map the relevant role_order for this author to a data-part which is not used for output: person:id (this data-part only normally takes effect) during deposit xwalks. -->
+          <!-- This value will be used in an overriden XSL template which will be added to the Custom\hyrax-XwalkIn.xsl file, which will apply a sort before rendering author-list fields. -->
+          <xwalk:field-source data-part="person:id" from="/*/mods:role[mods:roleTerm/text() = 'Author']/mods:extension/ora:role_order" select-using="xpath" />
           <xwalk:field-source data-part="person:identifier" from="nameIdentifier">
             <xwalk:field-source data-part="identifier:scheme" from="@type" value-map="name-identifier"/>
             <xwalk:field-source data-part="identifier:value" from="."/>
@@ -399,6 +403,10 @@ ISSUES:
         <xwalk:field-source from="/mods:mods/mods:name[@type = 'personal' and mods:role/mods:roleTerm/text() = 'Editor']" select-using="xpath">
           <xwalk:field-source data-part="person:firstnames" from="/*/mods:namePart[@type = 'given']" select-using="xpath"/>
           <xwalk:field-source data-part="person:lastname" from="/*/mods:namePart[@type = 'family']" select-using="xpath"/>
+          <!-- Workaround author ordering issue - GitHub issue 181 (https://github.com/tomwrobel/ora_data_model/issues/181), support ticket https://support.symplectic.co.uk/a/tickets/260733. -->
+          <!-- Map the relevant role_order for this author to a data-part which is not used for output: person:id (this data-part only normally takes effect) during deposit xwalks. -->
+          <!-- This value will be used in an overriden XSL template which will be added to the Custom\hyrax-XwalkIn.xsl file, which will apply a sort before rendering author-list fields. -->
+          <xwalk:field-source data-part="person:id" from="/*/mods:role[mods:roleTerm/text() = 'Editor']/mods:extension/ora:role_order" select-using="xpath" />
           <xwalk:field-source data-part="person:identifier" from="nameIdentifier">
             <xwalk:field-source data-part="identifier:scheme" from="@type" value-map="name-identifier"/>
             <xwalk:field-source data-part="identifier:value" from="."/>
@@ -413,6 +421,10 @@ ISSUES:
         <xwalk:field-source from="/mods:mods/mods:name[@type = 'personal' and mods:role/mods:roleTerm/text() = 'Translator']" select-using="xpath">
           <xwalk:field-source data-part="person:firstnames" from="/*/mods:namePart[@type = 'given']" select-using="xpath"/>
           <xwalk:field-source data-part="person:lastname" from="/*/mods:namePart[@type = 'family']" select-using="xpath"/>
+          <!-- Workaround author ordering issue - GitHub issue 181 (https://github.com/tomwrobel/ora_data_model/issues/181), support ticket https://support.symplectic.co.uk/a/tickets/260733. -->
+          <!-- Map the relevant role_order for this author to a data-part which is not used for output: person:id (this data-part only normally takes effect) during deposit xwalks. -->
+          <!-- This value will be used in an overriden XSL template which will be added to the Custom\hyrax-XwalkIn.xsl file, which will apply a sort before rendering author-list fields. -->
+          <xwalk:field-source data-part="person:id" from="/*/mods:role[mods:roleTerm/text() = 'Translator']/mods:extension/ora:role_order" select-using="xpath" />
           <xwalk:field-source data-part="person:identifier" from="nameIdentifier">
             <xwalk:field-source data-part="identifier:scheme" from="@type" value-map="name-identifier"/>
             <xwalk:field-source data-part="identifier:value" from="."/>
@@ -427,6 +439,10 @@ ISSUES:
         <xwalk:field-source from="/mods:mods/mods:name[@type = 'personal' and mods:role/mods:roleTerm/text() = 'Contributor']" select-using="xpath">
           <xwalk:field-source data-part="person:firstnames" from="/*/mods:namePart[@type = 'given']" select-using="xpath"/>
           <xwalk:field-source data-part="person:lastname" from="/*/mods:namePart[@type = 'family']" select-using="xpath"/>
+          <!-- Workaround author ordering issue - GitHub issue 181 (https://github.com/tomwrobel/ora_data_model/issues/181), support ticket https://support.symplectic.co.uk/a/tickets/260733. -->
+          <!-- Map the relevant role_order for this author to a data-part which is not used for output: person:id (this data-part only normally takes effect) during deposit xwalks. -->
+          <!-- This value will be used in an overriden XSL template which will be added to the Custom\hyrax-XwalkIn.xsl file, which will apply a sort before rendering author-list fields. -->
+          <xwalk:field-source data-part="person:id" from="/*/mods:role[mods:roleTerm/text() = 'Contributor']/mods:extension/ora:role_order" select-using="xpath" />
           <xwalk:field-source data-part="person:identifier" from="nameIdentifier">
             <xwalk:field-source data-part="identifier:scheme" from="@type" value-map="name-identifier"/>
             <xwalk:field-source data-part="identifier:value" from="."/>


### PR DESCRIPTION
## Workaround to issue https://github.com/tomwrobel/ora_data_model/issues/181 

The solution I've come up has two parts.

### 1. 
Add a mapping of the `ora:role_order` value to a data-part which normally does not get used in person-list output (`person:id` - normally only used in deposit maps). E.g., add

    <xwalk:field-source data-part="person:id" from="ora:role_order" />

to each person-list field-source. (The field-source above is a simplification). These mappings have been added as part of this pull request.

### 2. 
Add the following fragment to the file found in the Elements installation directory, at `AdvancedConfiguration\XwalkXsl\Custom\hyrax-XwalkIn.xsl`. Note that this file is designed to allow changes be made to it outside of regular Elements patches and upgrades, which is why we can take this approach rather than scheduling a full patch release.

```xsl
<!-- Override to order the person-list fields according to person:id field. See https://github.com/tomwrobel/ora_data_model/issues/181 -->
<!-- or https://support.symplectic.co.uk/a/tickets/260733 for details. -->
<xsl:template name="RenderValuePersonList">
  <xsl:param name="pFieldMapping"/>
  <xsl:param name="pSourceFieldValues"/>
  <xsl:param name="pNodeName" select="'api:people'"/>

  <xsl:element name="{$pNodeName}">
    <xsl:for-each select="$pSourceFieldValues">
      <!-- The following line is the only difference between this template and the one it overrides. Sort the  -->
      <!-- person-list entries according to a (normally non-functional) data-part to which the order value has been mapped. -->
      <xsl:sort data-type="number" select="./_value[@data-part = 'person:id']"/>
      <xsl:call-template name="RenderApiPerson">
        <xsl:with-param name="pSourceFieldValue" select="."/>
      </xsl:call-template>
    </xsl:for-each>
  </xsl:element>

</xsl:template>
```

This fragment should be added near the end of the file, **just prior** to the final line of the file which should read `</xsl:stylesheet>` (and so just after the line which starts `<xsl:param name ="gpMapFile"`).

### Future
Upon upgrade of Elements to v5.20, this workaround will cease to work. I'll investigate solutions for the upcoming release of Elements, but bear in mind that a change will be required to the map file -- likely it will be small, perhaps along the lines of changing `person:id` to `list:sort-index` (but still TBC).