### PR TITLE
Switch "temp:value1" workaround to syntax released in 5.21 ($list.index)

### DIFF
--- a/elements_xwalks/maps/hyrax-XwalkOut-map.xml
+++ b/elements_xwalks/maps/hyrax-XwalkOut-map.xml
@@ -598,8 +598,7 @@ Removed incorrect crosswalks form publisher-url (if device/product ->manufacture
           </xwalk:field-source>
           <xwalk:field-source subfield="role">
             <xwalk:field-source subfield="mods:extension">
-              <!-- 'temp:value1' is used temporarily as the person index -->
-              <xwalk:field-source data-part="temp:value1" subfield="ora:role_order"/>
+              <xwalk:field-source from="$list.index" subfield="ora:role_order"/>
             </xwalk:field-source>
             <xwalk:field-source subfield="roleTerm">
               <xwalk:field-source subfield="@type" value="text"/>
@@ -685,8 +684,7 @@ Removed incorrect crosswalks form publisher-url (if device/product ->manufacture
           </xwalk:field-source>
           <xwalk:field-source subfield="role">
             <xwalk:field-source subfield="mods:extension">
-              <!-- 'temp:value1' is used temporarily as the person index -->
-              <xwalk:field-source data-part="temp:value1" subfield="ora:role_order"/>
+              <xwalk:field-source from="$list.index" subfield="ora:role_order"/>
             </xwalk:field-source>
             <xwalk:field-source subfield="roleTerm">
               <xwalk:field-source subfield="@type" value="text"/>
@@ -772,8 +770,7 @@ Removed incorrect crosswalks form publisher-url (if device/product ->manufacture
           </xwalk:field-source>
           <xwalk:field-source subfield="role">
             <xwalk:field-source subfield="mods:extension">
-              <!-- 'temp:value1' is used temporarily as the person index -->
-              <xwalk:field-source data-part="temp:value1" subfield="ora:role_order"/>
+              <xwalk:field-source data-part="$list.index" subfield="ora:role_order"/>
             </xwalk:field-source>
             <xwalk:field-source subfield="roleTerm">
               <xwalk:field-source subfield="@type" value="text"/>
@@ -859,8 +856,7 @@ Removed incorrect crosswalks form publisher-url (if device/product ->manufacture
           </xwalk:field-source>
           <xwalk:field-source subfield="role">
             <xwalk:field-source subfield="mods:extension">
-              <!-- 'temp:value1' is used temporarily as the person index -->
-              <xwalk:field-source data-part="temp:value1" subfield="ora:role_order"/>
+              <xwalk:field-source from="$list.index" subfield="ora:role_order"/>
             </xwalk:field-source>
             <xwalk:field-source subfield="roleTerm">
               <xwalk:field-source subfield="@type" value="text"/>


### PR DESCRIPTION
Hi all,

Just a note to say that we've added some built-in "list index access" functionality for Elements v5.21. Part of this work deprecated the workaround that was undocumented and in place for the Hyrax xwalk out role_order mappings (using "temp:value1" data-part).

I've switched these to use the new syntax (`from="$list.index"`) - this should be applied when upgraded to Elements v5.21.

